### PR TITLE
Remove pairs from roadmap

### DIFF
--- a/roadmaps/models.py
+++ b/roadmaps/models.py
@@ -46,3 +46,9 @@ class RoadmapProcedureLink(models.Model):
         quiried_procedures = RoadmapProcedureLink.objects.filter(roadmap=current_roadmap.id, procedure=current_procedure.id)
         for procedure in quiried_procedures:
             procedure.phase = new_phase_number
+
+    @staticmethod
+    def remove_pair_from_roadmap(roadmap_id,procedure_id, phase_number ):
+        queried_pairs = RoadmapProcedureLink.objects.filter(roadmap=roadmap_id, procedure=procedure_id, phase=phase_number)
+        for item in queried_pairs:
+            item.delete()

--- a/roadmaps/models.py
+++ b/roadmaps/models.py
@@ -15,6 +15,8 @@ class Roadmap(models.Model):
             roadmap.roadmap_name = new_roadmap_name
 
 
+
+
 class RoadmapProcedureLink(models.Model):
     roadmap = models.ManyToManyField(Roadmap)
     procedure = models.ManyToManyField(Procedure)
@@ -50,5 +52,11 @@ class RoadmapProcedureLink(models.Model):
     @staticmethod
     def remove_pair_from_roadmap(roadmap_id,procedure_id, phase_number ):
         queried_pairs = RoadmapProcedureLink.objects.filter(roadmap=roadmap_id, procedure=procedure_id, phase=phase_number)
+        for item in queried_pairs:
+            item.delete()
+
+    @staticmethod
+    def remove_all_pairs_from_roadmap(roadmap_id):
+        queried_pairs = RoadmapProcedureLink.objects.filter(roadmap=roadmap_id)
         for item in queried_pairs:
             item.delete()

--- a/roadmaps/templates/modify_roadmap.html
+++ b/roadmaps/templates/modify_roadmap.html
@@ -47,7 +47,28 @@
                     {% endfor %}
                     </tbody>
                 </table>
-            <button type="submit" class="btn btn-warning my-4"> Remove Selected Pairs</button>
+                <button type="button" class="btn btn-warning my-4" data-toggle="modal" data-target="#removePairs">
+                    Remove Selected Pairs
+                </button>
+                <div class="modal fade" id="removePairs" tabindex="-1" role="dialog" aria-labelledby="removePairsLabel"
+                     aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h4 class="modal-title" id="removePairsLabel">Remove Selected Pairs</h4>
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </div>
+                            <div class="modal-body">
+                                <h5>Are you sure?</h5>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="submit" class="btn btn-warning mb-4">Removed Selected Pairs</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </form>
         </div>
     </div>

--- a/roadmaps/templates/modify_roadmap.html
+++ b/roadmaps/templates/modify_roadmap.html
@@ -64,7 +64,7 @@
                                 <h5>Are you sure?</h5>
                             </div>
                             <div class="modal-footer">
-                                <button type="submit" class="btn btn-warning mb-4">Removed Selected Pairs</button>
+                                <button type="submit" class="btn btn-danger mb-4">Removed Selected Pairs</button>
                             </div>
                         </div>
                     </div>

--- a/roadmaps/templates/modify_roadmap.html
+++ b/roadmaps/templates/modify_roadmap.html
@@ -70,6 +70,30 @@
                     </div>
                 </div>
             </form>
+            <form action="/roadmaps/view_roadmap/delete/" method="post">{% csrf_token %}
+            <button type="button" class="btn btn-danger my-4" data-toggle="modal" data-target="#deleteRoadmap">
+                    Delete Roadmap
+                </button>
+                <div class="modal fade" id="deleteRoadmap" tabindex="-1" role="dialog" aria-labelledby="deleteRoadmapLabel"
+                     aria-hidden="true">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h4 class="modal-title" id="deleteRoadmapLabel">Delete Roadmap: {{ roadmap.roadmap_name }}</h4>
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </div>
+                            <div class="modal-body">
+                                <h5>Are you sure?</h5>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="submit" class="btn btn-danger mb-4">Delete Roadmap</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </form>
         </div>
     </div>
 </div>

--- a/roadmaps/templates/modify_roadmap.html
+++ b/roadmaps/templates/modify_roadmap.html
@@ -28,25 +28,27 @@
             </form>
         </div>
         <div class="container-fixed">
-            <table class="table table-hover">
-                <thead>
-                <tr>
-                    <th scope="col">Procedure Name</th>
-                    <th scope="col">Phase</th>
-                    <th scope="col">Modify Item</th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for procedure, phase in roadmap_pairs|dictsort:1 %}
+            <form action="/roadmaps/view_roadmap/remove/" method="post">{% csrf_token %}
+                <table class="table table-hover">
+                    <thead>
                     <tr>
-                        <td>{{ procedure.procedure_name }}</td>
-                        <td>{{ phase }}</td>
-                        <td><input type="checkbox"></td>
+                        <th scope="col">Procedure Name</th>
+                        <th scope="col">Phase</th>
+                        <th scope="col">Modify Item</th>
                     </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-
+                    </thead>
+                    <tbody>
+                    {% for procedure, phase in roadmap_pairs|dictsort:1 %}
+                        <tr>
+                            <td>{{ procedure.procedure_name }}</td>
+                            <td>{{ phase }}</td>
+                            <td><input type="checkbox" name="selection[]" value="{{ procedure.id }},{{ phase }}"></td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            <button type="submit" class="btn btn-warning my-4"> Remove Selected Pairs</button>
+            </form>
         </div>
     </div>
 </div>

--- a/roadmaps/tests_views.py
+++ b/roadmaps/tests_views.py
@@ -2,7 +2,8 @@ from django.test import RequestFactory, TestCase
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.contrib.auth.models import User
 from procedures.views import new_procedure
-from roadmaps.views import roadmaps_index, create_roadmap, view_roadmap, add_to_roadmap, remove_selected_pairs
+from roadmaps.views import roadmaps_index, create_roadmap, view_roadmap, add_to_roadmap, remove_selected_pairs, \
+    delete_roadmap
 from .models import Procedure, Roadmap, RoadmapProcedureLink
 
 
@@ -328,3 +329,93 @@ class TestProcedures(TestCase):
         response = remove_selected_pairs(remove_request)
 
         self.assertEqual(response.status_code, 302)
+
+    def test_delete_roadmap(self):
+        # View roadmap first
+        view_request = self.factory.post('/roadmaps/view_roadmap/?id=' + str(self.test_roadmap.id))
+        view_request.user = self.user
+        self.middleware.process_request(view_request)
+        view_request.session.save()
+
+        response = view_roadmap(view_request)
+
+        self.assertEqual(response.status_code, 200)
+
+        expected_list = [(self.test_object_one, 1), (self.test_object_two, 1), (self.test_object_three, 1)]
+
+        # Add procedure one, two, and three to phase one
+        add_request = self.factory.post('/roadmaps/view_roadmap/add/', {
+            'procedure': [self.test_object_one.id, self.test_object_two.id, self.test_object_three.id], 'phase': 1})
+
+        add_request.user = self.user
+        add_request.session = view_request.session
+
+        response = add_to_roadmap(add_request)
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertListEqual(expected_list, RoadmapProcedureLink.get_procedures_from_roadmap(self.test_roadmap))
+
+        # Delete the roadmap
+        delete_request = self.factory.post('/roadmaps/view_roadmap/delete/')
+
+        delete_request.user = self.user
+        delete_request.session = view_request.session
+
+        response = delete_roadmap(delete_request)
+
+        self.assertEqual(response.status_code, 302)
+
+        expected_list = []
+
+        # Assert there are no procedure-phase pairs since they've been deleted
+        self.assertListEqual(expected_list, RoadmapProcedureLink.get_procedures_from_roadmap(self.test_roadmap))
+
+        # Assert the roadmap itself no longer exists
+        self.assertListEqual(expected_list, list(Roadmap.objects.filter(id=self.test_roadmap.id)))
+
+    def test_delete_roadmap_bad_id(self):
+        # View roadmap first
+        view_request = self.factory.post('/roadmaps/view_roadmap/?id=' + str(self.test_roadmap.id))
+        view_request.user = self.user
+        self.middleware.process_request(view_request)
+        view_request.session.save()
+
+        response = view_roadmap(view_request)
+
+        self.assertEqual(response.status_code, 200)
+
+        expected_list = [(self.test_object_one, 1), (self.test_object_two, 1), (self.test_object_three, 1)]
+
+        # Add procedure one, two, and three to phase one
+        add_request = self.factory.post('/roadmaps/view_roadmap/add/', {
+            'procedure': [self.test_object_one.id, self.test_object_two.id, self.test_object_three.id], 'phase': 1})
+
+        add_request.user = self.user
+        add_request.session = view_request.session
+
+        response = add_to_roadmap(add_request)
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertListEqual(expected_list, RoadmapProcedureLink.get_procedures_from_roadmap(self.test_roadmap))
+
+        # Delete the roadmap
+        delete_request = self.factory.post('/roadmaps/view_roadmap/delete/')
+
+        delete_request.user = self.user
+        delete_request.session = view_request.session
+
+        # Fudge the roadmap_id stored
+        delete_request.session['roadmap_id'] = 99999
+
+        response = delete_roadmap(delete_request)
+
+        self.assertEqual(response.status_code, 302)
+
+        # Assert the list did not change since they weren't deleted
+        self.assertListEqual(expected_list, RoadmapProcedureLink.get_procedures_from_roadmap(self.test_roadmap))
+
+        expected_roadmap_list = [self.test_roadmap]
+        # Assert the roadmap itself no longer exists
+        self.assertListEqual(expected_roadmap_list, list(Roadmap.objects.filter(id=self.test_roadmap.id)))

--- a/roadmaps/urls.py
+++ b/roadmaps/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path('view_roadmap/', views.view_roadmap),
     path('view_roadmap/add/', views.add_to_roadmap),
     path('view_roadmap/remove/', views.remove_selected_pairs),
+    path('view_roadmap/delete/', views.delete_roadmap)
 ]

--- a/roadmaps/urls.py
+++ b/roadmaps/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
 from . import views
 
-
 urlpatterns = [
     path('', views.roadmaps_index, name='index'),
     path('create/', views.create_roadmap),
     path('view_roadmap/', views.view_roadmap),
     path('view_roadmap/add/', views.add_to_roadmap),
+    path('view_roadmap/remove/', views.remove_selected_pairs),
 ]

--- a/roadmaps/views.py
+++ b/roadmaps/views.py
@@ -76,7 +76,6 @@ def remove_selected_pairs(request):
     if request.method == 'POST':
         checked_boxes = request.POST.getlist('selection[]')
         roadmap_id = request.session['roadmap_id']
-        print(checked_boxes)
 
         for pair in checked_boxes:
             cleaned_pair = tuple(pair.split(','))

--- a/roadmaps/views.py
+++ b/roadmaps/views.py
@@ -59,7 +59,9 @@ def add_to_roadmap(request):
             cd = form.cleaned_data
             roadmap_id = request.session['roadmap_id']
             for procedure_item in cd['procedure']:
-                RoadmapProcedureLink.link_procedure_to_roadmap(procedure_item.id, roadmap_id, cd['phase'])
+                #If the item doesn't exist, add it
+                if not RoadmapProcedureLink.objects.filter(roadmap=roadmap_id, procedure=procedure_item.id, phase=cd['phase']):
+                    RoadmapProcedureLink.link_procedure_to_roadmap(procedure_item.id, roadmap_id, cd['phase'])
             try:
                 roadmap = Roadmap.objects.get(id=roadmap_id)
                 roadmap_pairs = RoadmapProcedureLink.get_procedures_from_roadmap(roadmap)

--- a/roadmaps/views.py
+++ b/roadmaps/views.py
@@ -91,3 +91,14 @@ def remove_selected_pairs(request):
                            'title': 'Modifying: ' + roadmap.roadmap_name})
         except Roadmap.DoesNotExist:
             return redirect('/roadmaps')
+
+def delete_roadmap(request):
+    if request.method == 'POST':
+        roadmap_id = request.session['roadmap_id']
+        try:
+            roadmap = Roadmap.objects.get(id=roadmap_id)
+            RoadmapProcedureLink.remove_all_pairs_from_roadmap(roadmap_id)
+            roadmap.delete()
+        except Roadmap.DoesNotExist:
+            return redirect('/homepage')
+        return redirect('/roadmaps')

--- a/roadmaps/views.py
+++ b/roadmaps/views.py
@@ -70,3 +70,23 @@ def add_to_roadmap(request):
                 return redirect('/roadmaps')
         else:
             return redirect('/homepage/')
+
+
+def remove_selected_pairs(request):
+    if request.method == 'POST':
+        checked_boxes = request.POST.getlist('selection[]')
+        roadmap_id = request.session['roadmap_id']
+        print(checked_boxes)
+
+        for pair in checked_boxes:
+            cleaned_pair = tuple(pair.split(','))
+            RoadmapProcedureLink.remove_pair_from_roadmap(roadmap_id, cleaned_pair[0],
+                                                          cleaned_pair[1])
+        try:
+            roadmap = Roadmap.objects.get(id=roadmap_id)
+            roadmap_pairs = RoadmapProcedureLink.get_procedures_from_roadmap(roadmap)
+            return render(request, 'modify_roadmap.html',
+                          {'form': RoadmapProcedureLinkForm(), 'roadmap_pairs': roadmap_pairs, 'roadmap': roadmap,
+                           'title': 'Modifying: ' + roadmap.roadmap_name})
+        except Roadmap.DoesNotExist:
+            return redirect('/roadmaps')


### PR DESCRIPTION
User can now select procedure-phase pairs to be removed from a roadmap, as well as delete the roadmap as a whole.