### PR TITLE
Patient checkboxes

### DIFF
--- a/assigned_procedures/models.py
+++ b/assigned_procedures/models.py
@@ -142,6 +142,7 @@ class AssignedProcedures(models.Model):
 
         for assignedProc in queriedAssignedProcedures:
             assignedProc.completed = True
+            assignedProc.date_completed = timezone.now()
             assignedProc.save()
 
     @staticmethod

--- a/assigned_procedures/models.py
+++ b/assigned_procedures/models.py
@@ -133,6 +133,23 @@ class AssignedProcedures(models.Model):
                 return False
 
     @staticmethod
+    def set_complete(searchPatient, searchProcedure, searchVisitID=1):
+        queriedAssignedProcedures = AssignedProcedures.objects.filter(patient=searchPatient.id, procedure=searchProcedure, visitID=searchVisitID)
+
+        for assignedProc in queriedAssignedProcedures:
+            assignedProc.completed = True
+            assignedProc.save()
+
+    @staticmethod
+    def set_incomplete(searchPatient, searchProcedure, searchVisitID=1):
+        queriedAssignedProcedures = AssignedProcedures.objects.filter(patient=searchPatient.id,
+                                                                      procedure=searchProcedure, visitID=searchVisitID)
+
+        for assignedProc in queriedAssignedProcedures:
+            assignedProc.completed = False
+            assignedProc.save()
+
+    @staticmethod
     def update_procedure_step(newStepNumber, searchPatient, searchProcedure, searchVisitID=1):
         quiriedAssignedProcedures = AssignedProcedures.objects.filter(patient=searchPatient.id,
                                                                       procedure=searchProcedure, visitID=searchVisitID)
@@ -229,3 +246,14 @@ class AssignedProcedures(models.Model):
         if total_days == 0:
             return "0"
         return str(int(math.floor(abs(total_days/total_procedures))))
+
+    @staticmethod
+    def get_first_incomplete_phase(assigned_procedure_dict, patient):
+        final_phase = 0
+        for phase, procedure_list in assigned_procedure_dict.items():
+            for procedure in procedure_list:
+                assigned_obj = AssignedProcedures.objects.get(patient=patient, procedure=procedure, phaseNumber=phase)
+                if not assigned_obj.completed:
+                    return phase
+            final_phase = phase
+        return final_phase

--- a/assigned_procedures/tests.py
+++ b/assigned_procedures/tests.py
@@ -217,3 +217,27 @@ class TestAssignedProcedures(TestCase):
         actual_return = AssignedProcedures.get_last_completed_date(testPatient)
 
         self.assertEqual(actual_return.date(), timezone.now().date())
+
+    def test_set_complete(self):
+        testAssign, testPatient, testProcedure = self.test_create_assignedProcedure()
+
+        self.assertFalse(testAssign.completed)
+
+        AssignedProcedures.set_complete(testPatient, testProcedure, testAssign.phaseNumber)
+
+        resultAssign = AssignedProcedures.objects.get(patient=testPatient, procedure=testProcedure, phaseNumber=testAssign.phaseNumber)
+
+        self.assertTrue(resultAssign.completed)
+
+        return resultAssign, testPatient, testProcedure
+
+    def test_set_incomplete(self):
+        testAssign, testPatient, testProcedure = self.test_set_complete()
+
+        self.assertTrue(testAssign.completed)
+
+        AssignedProcedures.set_incomplete(testPatient, testProcedure, testAssign.phaseNumber)
+
+        resultAssign = AssignedProcedures.objects.get(patient=testPatient, procedure=testProcedure, phaseNumber=testAssign.phaseNumber)
+
+        self.assertFalse(resultAssign.completed)

--- a/patients/static/patients/patient_profile.js
+++ b/patients/static/patients/patient_profile.js
@@ -1,15 +1,14 @@
 $(document).ready(function () {
 
 
-    $(".disabledBox").on("click", function (e) {
-        console.log("EEK")
-        var checkbox = $(this);
-        // do the confirmation thing here
+    $(".modalCheckbox").on("click", function (e) {
+        var checkboxClicked = $(this).children()[0];
 
+        console.log(checkboxClicked.id)
         e.preventDefault();
-        $('#exampleModalCenter').modal('toggle');
 
-        console.log(checkbox)
+        $('#' + checkboxClicked.id +'Modal').modal('toggle');
+
     });
 
 

--- a/patients/static/patients/patient_profile.js
+++ b/patients/static/patients/patient_profile.js
@@ -4,11 +4,28 @@ $(document).ready(function () {
     $(".modalCheckbox").on("click", function (e) {
         var checkboxClicked = $(this).children()[0];
 
-        console.log(checkboxClicked.id)
         e.preventDefault();
 
         $('#' + checkboxClicked.id +'Modal').modal('toggle');
 
+    });
+
+    $(".modalCheckButton").on("click", function(e){
+        console.log("EEEK");
+       var checkButtonID = e.target.id;
+       var checkboxID = checkButtonID.substring(0,3);
+
+       console.log(checkboxID);
+       var checkbox_element = $('#' + checkboxID);
+
+       console.log(checkbox_element);
+       if(checkbox_element.prop("checked") === true){
+           checkbox_element.prop("checked", false);
+       } else {
+           checkbox_element.prop("checked", true);
+       }
+
+        $(this).parent().parent().parent().parent().modal('toggle');
     });
 
 

--- a/patients/static/patients/patient_profile.js
+++ b/patients/static/patients/patient_profile.js
@@ -1,0 +1,16 @@
+$(document).ready(function () {
+
+
+    $(".disabledBox").on("click", function (e) {
+        console.log("EEK")
+        var checkbox = $(this);
+        // do the confirmation thing here
+
+        e.preventDefault();
+        $('#exampleModalCenter').modal('toggle');
+
+        console.log(checkbox)
+    });
+
+
+});

--- a/patients/templates/patient.html
+++ b/patients/templates/patient.html
@@ -185,22 +185,22 @@
                                                             <li>
                                                                 <div class="funkyradio-success {% if phase_num > first_incomplete_phase %}modalCheckbox{% endif %}">
                                                                     <input type="checkbox" name="selection[]"
-                                                                           value="{{ procedure.id }},{{ phase_num }}"
-                                                                           id="{{ procedure.id }},{{ phase_num }}"
+                                                                           value="{{ procedure.id }}-{{ phase_num }}"
+                                                                           id="{{ procedure.id }}-{{ phase_num }}"
                                                                             {% if completed %} checked {% endif %}/>
-                                                                    <label for="{{ procedure.id }},{{ phase_num }}">{{ procedure.procedure_name }}</label>
+                                                                    <label for="{{ procedure.id }}-{{ phase_num }}">{{ procedure.procedure_name }}</label>
                                                                 </div>
                                                                 {% if phase_num > first_incomplete_phase %}
                                                                     <div class="modal fade"
-                                                                         id="{{ procedure.id }},{{ phase_num }}Modal"
+                                                                         id="{{ procedure.id }}-{{ phase_num }}Modal"
                                                                          tabindex="-1" role="dialog"
-                                                                         aria-labelledby="{{ procedure.id }},{{ phase_num }}ModalLabel"
+                                                                         aria-labelledby="{{ procedure.id }}-{{ phase_num }}ModalLabel"
                                                                          aria-hidden="true">
                                                                         <div class="modal-dialog" role="document">
                                                                             <div class="modal-content">
                                                                                 <div class="modal-header">
                                                                                     <h5 class="modal-title"
-                                                                                        id="{{ procedure.id }},{{ phase_num }}ModalLabel">
+                                                                                        id="{{ procedure.id }}-{{ phase_num }}ModalLabel">
                                                                                         Modal title</h5>
                                                                                     <button type="button" class="close"
                                                                                             data-dismiss="modal"
@@ -214,7 +214,7 @@
                                                                                 <div class="modal-footer">
                                                                                     <button type="button"
                                                                                             class="btn btn-primary modalCheckButton"
-                                                                                            id="{{ procedure.id }},{{ phase_num }}-ModalButton">
+                                                                                            id="{{ procedure.id }}-{{ phase_num }}-ModalButton">
                                                                                         Toggle Checkbox
                                                                                     </button>
                                                                                 </div>
@@ -257,11 +257,11 @@
 
 </div>
 <!-- modal format for later
-<div class="modal fade" id="{{ procedure.id }},{{ phase_num }}Modal" tabindex="-1" role="dialog" aria-labelledby="{{ procedure.id }},{{ phase_num }}ModalLabel" aria-hidden="true">
+<div class="modal fade" id="{{ procedure.id }}-{{ phase_num }}Modal" tabindex="-1" role="dialog" aria-labelledby="{{ procedure.id }}-{{ phase_num }}ModalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="{{ procedure.id }},{{ phase_num }}ModalLabel">Modal title</h5>
+        <h5 class="modal-title" id="{{ procedure.id }}-{{ phase_num }}ModalLabel">Modal title</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -270,7 +270,7 @@
         ...
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary modalCheckButton" id="{{ procedure.id }},{{ phase_num }}-ModalButton">Toggle Checkbox</button>
+        <button type="button" class="btn btn-primary modalCheckButton" id="{{ procedure.id }}-{{ phase_num }}-ModalButton">Toggle Checkbox</button>
       </div>
     </div>
   </div>

--- a/patients/templates/patient.html
+++ b/patients/templates/patient.html
@@ -174,22 +174,33 @@
                                          aria-labelledby="headingAssignedProcedures"
                                          data-parent="#procedure-accordian">
                                         <div class="card-body funkyradio">
-                                            {% for phase_num, procedure_list in assigned_procedures.items %}
-                                                <h6>Phase: {{ phase_num }}</h6>
-                                                <ul class="list-unstyled">
-                                                    {% for procedure in procedure_list %}
-                                                        <li>
-                                                            <div class="funkyradio-success">
-                                                                <input type="checkbox" name="checkbox" id="
-                                                                        {{ procedure.procedure_name }}{{ phase_num }}"/>
-                                                                <label for="
-                                                                        {{ procedure.procedure_name }}{{ phase_num }}">{{ procedure.procedure_name }}</label>
-                                                            </div>
-                                                            <a class="text-primary" href="/assigned/procedure/?id={% assigned_procedure_id patient procedure phase_num %}">Update Info</a>
-                                                        </li>
-                                                    {% endfor %}
-                                                </ul>
-                                            {% endfor %}
+                                            <form action="/patients/profile/check_procedures/?id={{ patient.id }}"
+                                                  method="POST">
+                                                {% csrf_token %}
+                                                {% for phase_num, procedure_list in assigned_procedures.items %}
+                                                    <h6>Phase: {{ phase_num }}</h6>
+                                                    <ul class="list-unstyled">
+                                                        {% for procedure in procedure_list %}
+                                                            {% procedure_is_complete patient procedure phase_num as completed %}
+                                                            <li>
+                                                                <div class="funkyradio-success">
+                                                                    <input type="checkbox" name="selection[]"
+                                                                           value="{{ procedure.id }},{{ phase_num }}"
+                                                                           id="{{ procedure.id }},{{ phase_num }}"
+                                                                            {% if completed %} checked {% endif %}/>
+                                                                    <label for="{{ procedure.id }},{{ phase_num }}">{{ procedure.procedure_name }}</label>
+                                                                </div>
+                                                                <a class="text-primary"
+                                                                   href="/assigned/procedure/?id={% assigned_procedure_id patient procedure phase_num %}">Update
+                                                                    Info</a>
+                                                            </li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                {% endfor %}
+                                                <button type="submit" class="btn btn-warning">Save
+                                                    changes
+                                                </button>
+                                            </form>
                                         </div>
                                     </div>
                                 </div>
@@ -213,10 +224,31 @@
     </div>
 
 </div>
+<!-- modal format for later
+<div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLongTitle">Modal title</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        ...
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-primary">Save changes</button>
+      </div>
+    </div>
+  </div>
+</div>
 
-
+-->
 {% include "global_js.html" %}
 <!-- Personal JS -->
 <script src={% static "patients/patients.js" %}></script>
+<script src={% static "patients/patient_profile.js" %}></script>
 </body>
 </html>

--- a/patients/templates/patient.html
+++ b/patients/templates/patient.html
@@ -201,7 +201,7 @@
                                                                                 <div class="modal-header">
                                                                                     <h5 class="modal-title"
                                                                                         id="{{ procedure.id }}-{{ phase_num }}ModalLabel">
-                                                                                        Modal title</h5>
+                                                                                        Override Procedure Order?</h5>
                                                                                     <button type="button" class="close"
                                                                                             data-dismiss="modal"
                                                                                             aria-label="Close">
@@ -209,7 +209,7 @@
                                                                                     </button>
                                                                                 </div>
                                                                                 <div class="modal-body">
-                                                                                    ...
+                                                                                    Procedures that should be done before <strong>{{ procedure.procedure_name }}</strong> have not yet been completed. Are you sure you want to mark this as done?
                                                                                 </div>
                                                                                 <div class="modal-footer">
                                                                                     <button type="button"

--- a/patients/templates/patient.html
+++ b/patients/templates/patient.html
@@ -183,13 +183,45 @@
                                                         {% for procedure in procedure_list %}
                                                             {% procedure_is_complete patient procedure phase_num as completed %}
                                                             <li>
-                                                                <div class="funkyradio-success">
+                                                                <div class="funkyradio-success {% if phase_num > first_incomplete_phase %}modalCheckbox{% endif %}">
                                                                     <input type="checkbox" name="selection[]"
                                                                            value="{{ procedure.id }},{{ phase_num }}"
                                                                            id="{{ procedure.id }},{{ phase_num }}"
                                                                             {% if completed %} checked {% endif %}/>
                                                                     <label for="{{ procedure.id }},{{ phase_num }}">{{ procedure.procedure_name }}</label>
                                                                 </div>
+                                                                {% if phase_num > first_incomplete_phase %}
+                                                                    <div class="modal fade"
+                                                                         id="{{ procedure.id }},{{ phase_num }}Modal"
+                                                                         tabindex="-1" role="dialog"
+                                                                         aria-labelledby="{{ procedure.id }},{{ phase_num }}ModalLabel"
+                                                                         aria-hidden="true">
+                                                                        <div class="modal-dialog" role="document">
+                                                                            <div class="modal-content">
+                                                                                <div class="modal-header">
+                                                                                    <h5 class="modal-title"
+                                                                                        id="{{ procedure.id }},{{ phase_num }}ModalLabel">
+                                                                                        Modal title</h5>
+                                                                                    <button type="button" class="close"
+                                                                                            data-dismiss="modal"
+                                                                                            aria-label="Close">
+                                                                                        <span aria-hidden="true">&times;</span>
+                                                                                    </button>
+                                                                                </div>
+                                                                                <div class="modal-body">
+                                                                                    ...
+                                                                                </div>
+                                                                                <div class="modal-footer">
+                                                                                    <button type="button"
+                                                                                            class="btn btn-primary modalCheckButton"
+                                                                                            id="{{ procedure.id }},{{ phase_num }}-ModalButton">
+                                                                                        Toggle Checkbox
+                                                                                    </button>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                {% endif %}
                                                                 <a class="text-primary"
                                                                    href="/assigned/procedure/?id={% assigned_procedure_id patient procedure phase_num %}">Update
                                                                     Info</a>
@@ -225,11 +257,11 @@
 
 </div>
 <!-- modal format for later
-<div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered" role="document">
+<div class="modal fade" id="{{ procedure.id }},{{ phase_num }}Modal" tabindex="-1" role="dialog" aria-labelledby="{{ procedure.id }},{{ phase_num }}ModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLongTitle">Modal title</h5>
+        <h5 class="modal-title" id="{{ procedure.id }},{{ phase_num }}ModalLabel">Modal title</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -238,8 +270,7 @@
         ...
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary">Save changes</button>
+        <button type="button" class="btn btn-primary modalCheckButton" id="{{ procedure.id }},{{ phase_num }}-ModalButton">Toggle Checkbox</button>
       </div>
     </div>
   </div>

--- a/patients/templates/patient.html
+++ b/patients/templates/patient.html
@@ -178,7 +178,7 @@
                                                   method="POST">
                                                 {% csrf_token %}
                                                 {% for phase_num, procedure_list in assigned_procedures.items %}
-                                                    <h6>Phase: {{ phase_num }}</h6>
+                                                    <h5>Phase: {{ phase_num }}</h5>
                                                     <ul class="list-unstyled">
                                                         {% for procedure in procedure_list %}
                                                             {% procedure_is_complete patient procedure phase_num as completed %}

--- a/patients/urls.py
+++ b/patients/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path('profile/procedures/remove/', views.remove_pairs_from_patient),
     path('profile/flag/', views.flag_patient),
     path('profile/unflag/', views.unflag_patient),
+    path('profile/check_procedures/', views.checkbox_submission),
 ]

--- a/patients/views.py
+++ b/patients/views.py
@@ -308,7 +308,7 @@ def checkbox_submission(request):
             # In this array are the IDs of the boxes that were submitted checked. These are later set to complete.
             marked_boxes = []
             for pair in checked_boxes:
-                cleaned_pair = tuple(pair.split(','))
+                cleaned_pair = tuple(pair.split('-'))
                 marked_boxes.append(cleaned_pair[0])
 
             for assigned_procedure in procedures_assigned:

--- a/patients/views.py
+++ b/patients/views.py
@@ -306,23 +306,20 @@ def checkbox_submission(request):
             procedures_assigned = AssignedProcedures.objects.filter(patient=patient_obj)
 
             # In this array are the IDs of the boxes that were submitted checked. These are later set to complete.
-            marked_boxes = []
-            for pair in checked_boxes:
-                cleaned_pair = tuple(pair.split('-'))
-                marked_boxes.append(cleaned_pair[0])
+
 
             for assigned_procedure in procedures_assigned:
                 procedure_id = assigned_procedure.procedure.all()[0].id
                 procedure_obj = Procedure.objects.get(id=procedure_id)
-                if str(procedure_id) in marked_boxes:
-                    AssignedProcedures.set_complete(patient_obj, procedure_obj)
+                phase = assigned_procedure.phaseNumber
+
+                checkbox_id = str(procedure_id) + '-' + str(phase)
+                if str(checkbox_id) in checked_boxes:
+                    AssignedProcedures.set_complete(patient_obj, procedure_obj, phase)
                 else:
-                    AssignedProcedures.set_incomplete(patient_obj, procedure_obj)
+                    AssignedProcedures.set_incomplete(patient_obj, procedure_obj, phase)
 
             return redirect('/patients/profile/?id=' + str(patient_id))
         except Patients.DoesNotExist:
             messages.warning(request, "The patient you tried to reach doesn't exist!")
             return redirect('/patients/')
-        except Procedure.DoesNotExist:
-            messages.warning(request, "The procedure you tried to reach doesn't exist!")
-            return redirect('/procedures/')

--- a/roadmaps/templatetags/roadmap_extras.py
+++ b/roadmaps/templatetags/roadmap_extras.py
@@ -21,3 +21,8 @@ def assigned_procedure_id(patient, procedure, phase):
     for proc in procedures:
         procedure_id = proc.id
     return str(procedure_id)
+
+@register.simple_tag()
+def procedure_is_complete(patient, procedure, phase):
+    procedure = AssignedProcedures.objects.get(patient=patient, procedure=procedure, phaseNumber=phase)
+    return procedure.completed


### PR DESCRIPTION
Users can now use the checkboxes on a patient's profile to mark them for procedures being completed or not. Modals pop up for overriding the order of a patient's procedure map to allow flexibility in the system.